### PR TITLE
Add `Dockerfile` to support creation of hakken container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:6.10.3-alpine
+
+# Common ENV
+ENV API_SECRET="This is a local API secret for everyone. BsscSHqSHiwrBMJsEGqbvXiuIUPAjQXU" \
+    SERVER_SECRET="This needs to be the same secret everywhere. YaHut75NsK1f9UKUXuWqxNN0RUwHFBCy" \
+    LONGTERM_KEY="abcdefghijklmnopqrstuvwxyz" \
+    DISCOVERY_HOST=hakken:8000 \
+    PUBLISH_HOST=hakken \
+    METRICS_SERVICE="{ \"type\": \"static\", \"hosts\": [{ \"protocol\": \"http\", \"host\": \"highwater:9191\" }] }" \
+    USER_API_SERVICE="{ \"type\": \"static\", \"hosts\": [{ \"protocol\": \"http\", \"host\": \"shoreline:9107\" }] }" \
+    SEAGULL_SERVICE="{ \"type\": \"static\", \"hosts\": [{ \"protocol\": \"http\", \"host\": \"seagull:9120\" }] }" \
+    GATEKEEPER_SERVICE="{ \"type\": \"static\", \"hosts\": [{ \"protocol\": \"http\", \"host\": \"gatekeeper:9123\" }] }" \
+# Container specific ENV
+    ANNOUNCE_HOST=hakken \
+    PORT=8000 \
+    DISCOVERY_HEARTBEAT_INTERVAL=10000 \
+    LOG_HEARTBEATS=false
+
+WORKDIR /app
+
+COPY package.json /app/package.json
+RUN yarn install
+COPY . /app
+
+VOLUME /app
+USER node
+
+CMD ["node", "coordinator.js"]


### PR DESCRIPTION
Initial version of Dockerfile published to https://hub.docker.com/r/tidepool/hakken/

Add .dockerignore for smaller images.